### PR TITLE
[DRAFT] Drop submodules for npm git repo resolving

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/suite"]
-	path = test/suite
-	url = https://github.com/gdcorp-action-public-forks/JSON-Schema-Test-Suite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,239 @@
+{
+  "name": "jsonschema",
+  "version": "1.1.6",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jsonschema",
+      "version": "1.1.6",
+      "dependencies": {
+        "lodash": "~3.7.0"
+      },
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.5.0.tgz",
+      "integrity": "sha512-MmczsQrJwRYBBBhpOvqVMPw27OOjj1Bg0NwT4NzLh5dwdfAQKoFx7NuB7DifbAHqCENncQl7QXu8fPof3am/4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
+      "integrity": "sha512-BOZXenW4qYFnn8GhH24O4xfjF5CxT01uSYOfF/hGpTGFcs/50zc5nnF1AtV1ePP/ok4hGC9ZENrLtm5jjj16GA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha512-VWv7s1EI41AG2LiCr7uAuxWikLDN1SQOuEUc37d/P34NAIIYgkvWYngNw0d9d9iCrDFL0SYCE9UQpxhIjjtuLg==",
+      "dev": true
+    },
+    "node_modules/jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "bin": {
+        "jade": "bin/jade"
+      }
+    },
+    "node_modules/jade/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+      "integrity": "sha512-73GDDlioRJOCHV8N9gnBEpjdWI34+e9AvMnS4qdqdMfl8/yH/dJP1tfuqUFccZ/deZQlHuJiRSuKXjKIfDwBOg=="
+    },
+    "node_modules/mkdirp": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
+      "integrity": "sha512-Oamd41MnZw/yuxtarGf3MFbHzFqQY4S17DcN+rATh2t5MKuCtG7vVVRG+RUT6g9+hr47DIVucIHGOUlwmJRvDA==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.8.2.tgz",
+      "integrity": "sha512-+QeJMW92PTwTbz0i28m70eWLrvMyAr/2GBSW9mUD8y0HCcvvigNWk/6P7ahnlyw3pDeVVtoYLCUJV/UwBQaUjQ==",
+      "deprecated": "Mocha v1.x is no longer supported.",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "debug": "*",
+        "diff": "1.0.2",
+        "growl": "1.7.x",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.3",
+        "ms": "0.3.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/ms": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz",
+      "integrity": "sha512-25BVmSAdN4KRX7XeI6/gwQ9ewx6t9QB9/8X2fVJUUDpPc03qTRaEPgt5bTMZQ5T2l+XT+haSfqIkysOupDsSVQ==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "chai": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.5.0.tgz",
+      "integrity": "sha512-MmczsQrJwRYBBBhpOvqVMPw27OOjj1Bg0NwT4NzLh5dwdfAQKoFx7NuB7DifbAHqCENncQl7QXu8fPof3am/4Q==",
+      "dev": true
+    },
+    "commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
+      "integrity": "sha512-BOZXenW4qYFnn8GhH24O4xfjF5CxT01uSYOfF/hGpTGFcs/50zc5nnF1AtV1ePP/ok4hGC9ZENrLtm5jjj16GA==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha512-VWv7s1EI41AG2LiCr7uAuxWikLDN1SQOuEUc37d/P34NAIIYgkvWYngNw0d9d9iCrDFL0SYCE9UQpxhIjjtuLg==",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+      "integrity": "sha512-73GDDlioRJOCHV8N9gnBEpjdWI34+e9AvMnS4qdqdMfl8/yH/dJP1tfuqUFccZ/deZQlHuJiRSuKXjKIfDwBOg=="
+    },
+    "mkdirp": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
+      "integrity": "sha512-Oamd41MnZw/yuxtarGf3MFbHzFqQY4S17DcN+rATh2t5MKuCtG7vVVRG+RUT6g9+hr47DIVucIHGOUlwmJRvDA==",
+      "dev": true
+    },
+    "mocha": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.8.2.tgz",
+      "integrity": "sha512-+QeJMW92PTwTbz0i28m70eWLrvMyAr/2GBSW9mUD8y0HCcvvigNWk/6P7ahnlyw3pDeVVtoYLCUJV/UwBQaUjQ==",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "debug": "*",
+        "diff": "1.0.2",
+        "growl": "1.7.x",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.3",
+        "ms": "0.3.0"
+      }
+    },
+    "ms": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz",
+      "integrity": "sha512-25BVmSAdN4KRX7XeI6/gwQ9ewx6t9QB9/8X2fVJUUDpPc03qTRaEPgt5bTMZQ5T2l+XT+haSfqIkysOupDsSVQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "description": "A fast and easy to use JSON Schema validator",
   "scripts": {
-    "submoduleUpdate": "git submodule update --init --recursive && git submodule foreach git pull origin master",
     "test": "./node_modules/.bin/mocha -R spec"
   }
 }


### PR DESCRIPTION
Depending on git repos is a bad idea to start with. However, api-gateway currently does but there appears to be an issue with npm resolving git repos which include submodules.

This PR removes the submodule which wasn't even being used by the repo in its current state.